### PR TITLE
Fix Docker limit using dependency proxy (FE)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,12 @@ stages:
   - test
   - build
 
+variables:
+  # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
+  DOCKER_HOST: tcp://docker:2375/
+  DOCKER_DRIVER: overlay2
+  # See https://github.com/docker-library/docker/pull/166
+  DOCKER_TLS_CERTDIR: ""
 
 ## Test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,5 +53,11 @@ docker-build:
   before_script:
     - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
   script:
+    # this two lines fix "cgroups: cgroup mountpoint does not exist: unknown"
+    # job: https://gitlab.ebi.ac.uk/ensembl-apps/thr_frontend/-/jobs/741260
+    # got them from: https://github.com/docker/for-linux/issues/219
+    - sudo mkdir /sys/fs/cgroup/systemd
+    - sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+    # build and push
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
   # install npx globally to fix "npx: command not found" error
-  - npm install -g npx
+  - npm install -g npx --force
   - npm -v
   - npm install
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ build:
   needs: ["test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
   services:
-    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12-dind
+    - name: docker:19.03.12-dind
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,11 +14,10 @@ stages:
 
 variables:
   # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
-  # Environemt Variable for docker:dind service explaining to use overlay2 as supporting driver for docker
+  DOCKER_HOST: tcp://docker:2375/
   DOCKER_DRIVER: overlay2
-  # Use TLS https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#tls-enabled
-  DOCKER_HOST: tcp://docker:2376
-  DOCKER_TLS_CERTDIR: "/certs"
+  # See https://github.com/docker-library/docker/pull/166
+  DOCKER_TLS_CERTDIR: ""
 
 ## Test
 
@@ -43,7 +42,7 @@ build:
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
   before_script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_TOKEN $CI_REGISTRY
+    - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
   script:
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ docker-build:
   needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
   services:
-    - name: docker:19.03.12-dind
+    - name: docker:dind
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
   # By using before_script here we override the global one as we don't need npm ;)
@@ -56,8 +56,8 @@ docker-build:
     # this two lines fix "cgroups: cgroup mountpoint does not exist: unknown"
     # job: https://gitlab.ebi.ac.uk/ensembl-apps/thr_frontend/-/jobs/741260
     # got them from: https://github.com/docker/for-linux/issues/219
-    - mkdir /sys/fs/cgroup/systemd
-    - mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+#    - sudo mkdir /sys/fs/cgroup/systemd
+#    - sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
     # build and push
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,12 @@
-# GitLab Dependency Proxy to get rid of Docker hub pull limit issue
-# https://docs.gitlab.com/ee/user/packages/dependency_proxy/#authenticate-within-cicd
-image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
+stages:
+  - test
+  - build
 
 before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
   - npm -v
   - npm install
-
-stages:
-  - test
-  - build
 
 variables:
   # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
@@ -21,19 +17,27 @@ variables:
 
 ## Test
 
-lint:
+lint-test:
   stage: test
   script:
     - npm run lint
 
-test:
+unit-test:
   stage: test
   script:
     - npm test
 
 ## Build
 
-build:
+app-build:
+  stage: build
+    needs: ["test"]
+    script:
+      # fix: "Browserslist: caniuse-lite is outdated"
+      - npx browserslist@latest --update-db
+      - npm run build
+
+docker-build:
   stage: build
   needs: ["test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
@@ -43,9 +47,5 @@ build:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
   script:
     - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
-    # fix: "Browserslist: caniuse-lite is outdated"
-    - npx browserslist@latest --update-db
-    - npm run build
-    # push to gitlab
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,11 +31,11 @@ unit-test:
 
 app-build:
   stage: build
-    needs: ["test"]
-    script:
-      # fix: "Browserslist: caniuse-lite is outdated"
-      - npx browserslist@latest --update-db
-      - npm run build
+  needs: ["test"]
+  script:
+    # fix: "Browserslist: caniuse-lite is outdated"
+    - npx browserslist@latest --update-db
+    - npm run build
 
 docker-build:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,6 @@ image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
 before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
-  # install npx globally to fix "npx: command not found" error
-  - npm install -g npx --force
   - npm -v
   - npm install
 
@@ -43,9 +41,8 @@ build:
     - name: docker:19.03.12-dind
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
-  before_script:
-    - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
   script:
+    - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db
     - npm run build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ build:
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
   before_script:
-    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_TOKEN $CI_REGISTRY
   script:
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,17 @@ test:
 build:
   stage: build
   needs: ["test"]
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12-dind
+  variables:
+    IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   script:
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db
     - npm run build
+    # push to gitlab
+    - docker build -t $IMAGE_TAG .
+    - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,8 @@ docker-build:
     # this two lines fix "cgroups: cgroup mountpoint does not exist: unknown"
     # job: https://gitlab.ebi.ac.uk/ensembl-apps/thr_frontend/-/jobs/741260
     # got them from: https://github.com/docker/for-linux/issues/219
-    - sudo mkdir /sys/fs/cgroup/systemd
-    - sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+    - mkdir /sys/fs/cgroup/systemd
+    - mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
     # build and push
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,11 @@ stages:
 
 variables:
   # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
-  DOCKER_HOST: tcp://docker:2375/
+  # Environemt Variable for docker:dind service explaining to use overlay2 as supporting driver for docker
   DOCKER_DRIVER: overlay2
-  # See https://github.com/docker-library/docker/pull/166
-  DOCKER_TLS_CERTDIR: ""
+  # Use TLS https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#tls-enabled
+  DOCKER_HOST: tcp://docker:2376
+  DOCKER_TLS_CERTDIR: "/certs"
 
 ## Test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ stages:
   - test
   - build
 
-# CAREFUL! global before_script are not executed when job has its own before_script
+# KEEP IN MIND! global before_script is not executed when job has its own before_script
 before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
@@ -20,11 +20,13 @@ variables:
 
 lint-test:
   stage: test
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
     - npm run lint
 
 unit-test:
   stage: test
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
     - npm test
 
@@ -33,6 +35,7 @@ unit-test:
 app-build:
   stage: build
   needs: ["unit-test"]
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db
@@ -46,7 +49,9 @@ docker-build:
     - name: docker:19.03.12-dind
   variables:
     IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
-  script:
+  # By using before_script here we override the global one as we don't need npm ;)
+  before_script:
     - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
+  script:
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,15 @@ before_script:
   - npm -v
   - npm install
 
+# This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
 variables:
-  # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
+  # DOCKER_HOST variable tells docker how to connect to the daemon (a background service running inside the Docker VM)
   DOCKER_HOST: tcp://docker:2375/
+  # Environemt Variable for docker:dind service explaining to use overlay2 as supporting driver for docker
+  # https://docs.docker.com/storage/storagedriver/overlayfs-driver/
   DOCKER_DRIVER: overlay2
-  # See https://github.com/docker-library/docker/pull/166
+  # We need to disable TLS (https://about.gitlab.com/blog/2019/07/31/docker-in-docker-with-docker-19-dot-03/#disable-tls)
+  # to fix the error "docker: Cannot connect to the Docker daemon at tcp://docker:2375. Is the docker daemon running?"
   DOCKER_TLS_CERTDIR: ""
 
 ## Test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,13 +18,13 @@ variables:
 
 ## Test
 
-.lint-test:
+lint-test:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
     - npm run lint
 
-.unit-test:
+unit-test:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
@@ -32,7 +32,7 @@ variables:
 
 ## Build
 
-.app-build:
+app-build:
   stage: build
   needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
@@ -43,7 +43,7 @@ variables:
 
 docker-build:
   stage: build
-#  needs: ["unit-test"]
+  needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
   services:
     - name: docker:dind
@@ -53,11 +53,5 @@ docker-build:
   before_script:
     - echo $CI_REGISTRY_TOKEN | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
   script:
-    # this two lines fix "cgroups: cgroup mountpoint does not exist: unknown"
-    # job: https://gitlab.ebi.ac.uk/ensembl-apps/thr_frontend/-/jobs/741260
-    # got them from: https://github.com/docker/for-linux/issues/219
-#    - sudo mkdir /sys/fs/cgroup/systemd
-#    - sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
-    # build and push
     - docker build -t $IMAGE_TAG .
     - docker push $IMAGE_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
 
 docker-build:
   stage: build
-  needs: ["unit-test"]
+#  needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
   services:
     - name: docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,13 +18,13 @@ variables:
 
 ## Test
 
-lint-test:
+.lint-test:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
     - npm run lint
 
-unit-test:
+.unit-test:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
   script:
@@ -32,7 +32,7 @@ unit-test:
 
 ## Build
 
-app-build:
+.app-build:
   stage: build
   needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
 before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
+  # install npx globally to fix "npx: command not found" error
+  - npm install -g npx
   - npm -v
   - npm install
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - test
   - build
 
+# CAREFUL! global before_script are not executed when job has its own before_script
 before_script:
   # upgrade npm
   - npm install -g npm@7.11.1
@@ -31,7 +32,7 @@ unit-test:
 
 app-build:
   stage: build
-  needs: ["test"]
+  needs: ["unit-test"]
   script:
     # fix: "Browserslist: caniuse-lite is outdated"
     - npx browserslist@latest --update-db
@@ -39,7 +40,7 @@ app-build:
 
 docker-build:
   stage: build
-  needs: ["test"]
+  needs: ["unit-test"]
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:19.03.12
   services:
     - name: docker:19.03.12-dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
-image: node:14.17.3
+# GitLab Dependency Proxy to get rid of Docker hub pull limit issue
+# https://docs.gitlab.com/ee/user/packages/dependency_proxy/#authenticate-within-cicd
+image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/node:14.17.3
 
 before_script:
   # upgrade npm


### PR DESCRIPTION
- Fix Docker limit using dependency proxy.
- Add build and push the image to GitLab container registry.

More details of how dependency proxy works: https://docs.gitlab.com/ee/user/packages/dependency_proxy